### PR TITLE
Feature/20 add headline component

### DIFF
--- a/frontend/components/Headline/Headline.tsx
+++ b/frontend/components/Headline/Headline.tsx
@@ -9,35 +9,23 @@ type HeadlineProps = {
     hasMargin?: boolean
 }
 
+/** Defines the classes for each size level */
+const textSizes: { [K in Required<HeadlineProps>["level"]]: string } = {
+    1: "text-3xl md:text-4xl",
+    2: "text-2xl md:text-3xl",
+    3: "text-xl md:text-2xl",
+    4: "text-lg md:text-xl",
+    5: "text-base md:text-lg",
+    6: ""
+}
+
 /**
  * Custom Headline Component, to easy handle headlines with different level and adjustive styles
  */
 export const Headline: React.FC<HeadlineProps> = ({ level = 1, children, hasMargin = true }) => {
     const CustomTag = `h${level}` as keyof JSX.IntrinsicElements
 
-    // Generate text size class depending on level
-    let textSize = ""
-    switch (level) {
-        case 1:
-            textSize = "text-3xl md:text-4xl"
-            break
-        case 2:
-            textSize = "text-2xl md:text-3xl"
-            break
-        case 3:
-            textSize = "text-xl md:text-2xl"
-            break
-        case 4:
-            textSize = "text-lg md:text-xl"
-            break
-        case 5:
-            textSize = "text-base md:text-lg"
-            break
-        case 6:
-            textSize = ""
-    }
-
     return (
-        <CustomTag className={`${textSize} font-semibold ${hasMargin ? "mb-2 md:mb-4" : ""}`}>{children}</CustomTag>
+        <CustomTag className={`${textSizes[level]} font-semibold ${hasMargin ? "mb-2 md:mb-4" : ""}`}>{children}</CustomTag>
     )
 }

--- a/frontend/components/Headline/Headline.tsx
+++ b/frontend/components/Headline/Headline.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+type HeadlineProps = {
+    /** Content of Headline */
+    children: React.ReactNode
+    /** Specifies if its an h1, h2, h3,... */
+    level?: 1 | 2 | 3 | 4 | 5 | 6
+    /** If true adds margin */
+    hasMargin?: boolean
+}
+
+export const Headline: React.FC<HeadlineProps> = ({ level = 1, children, hasMargin = true }) => {
+    const CustomTag = `h${level}` as keyof JSX.IntrinsicElements
+
+    return (
+        <CustomTag className={`text-2xl md:text-xl font-semibold ${hasMargin ? "mb-2 md:mb-4" : ""}`}>{children}</CustomTag>
+    )
+}

--- a/frontend/components/Headline/Headline.tsx
+++ b/frontend/components/Headline/Headline.tsx
@@ -12,7 +12,29 @@ type HeadlineProps = {
 export const Headline: React.FC<HeadlineProps> = ({ level = 1, children, hasMargin = true }) => {
     const CustomTag = `h${level}` as keyof JSX.IntrinsicElements
 
+    // Generate text size class depending on level
+    let textSize = ""
+    switch (level) {
+        case 1:
+            textSize = "text-3xl md:text-4xl"
+            break
+        case 2:
+            textSize = "text-2xl md:text-3xl"
+            break
+        case 3:
+            textSize = "text-xl md:text-2xl"
+            break
+        case 4:
+            textSize = "text-lg md:text-xl"
+            break
+        case 5:
+            textSize = "text-base md:text-lg"
+            break
+        case 6:
+            textSize = ""
+    }
+
     return (
-        <CustomTag className={`text-2xl md:text-xl font-semibold ${hasMargin ? "mb-2 md:mb-4" : ""}`}>{children}</CustomTag>
+        <CustomTag className={`${textSize} font-semibold ${hasMargin ? "mb-2 md:mb-4" : ""}`}>{children}</CustomTag>
     )
 }

--- a/frontend/components/Headline/Headline.tsx
+++ b/frontend/components/Headline/Headline.tsx
@@ -9,6 +9,9 @@ type HeadlineProps = {
     hasMargin?: boolean
 }
 
+/**
+ * Custom Headline Component, to easy handle headlines with different level and adjustive styles
+ */
 export const Headline: React.FC<HeadlineProps> = ({ level = 1, children, hasMargin = true }) => {
     const CustomTag = `h${level}` as keyof JSX.IntrinsicElements
 


### PR DESCRIPTION
Closes #20 

@Zoe-Bot Hab das switch ersetzt. Fehlt noch was? Tests skippen wegen cypress: https://github.com/world-wide-weights/wwweights/discussions/26

- Adds base headline component 
![image](https://user-images.githubusercontent.com/47084064/200183115-2d6f1b2b-8661-49d8-9aae-a3c2c99f1422.png)
