### PR TITLE
Bug/238 image docker volume

### DIFF
--- a/backend/image/package-lock.json
+++ b/backend/image/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^9.2.1",
         "@nestjs/serve-static": "^3.0.0",
+        "class-transformer": "^0.5.1",
         "jwks-rsa": "^3.0.1",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.1.13",
@@ -3165,6 +3166,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -11842,6 +11848,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "cli-cursor": {
       "version": "3.1.0",

--- a/backend/image/package.json
+++ b/backend/image/package.json
@@ -29,6 +29,7 @@
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-express": "^9.2.1",
     "@nestjs/serve-static": "^3.0.0",
+    "class-transformer": "^0.5.1",
     "jwks-rsa": "^3.0.1",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",

--- a/backend/image/src/upload/responses/upload-image.response.ts
+++ b/backend/image/src/upload/responses/upload-image.response.ts
@@ -1,0 +1,6 @@
+import { Expose } from 'class-transformer';
+
+export class ImageUploadResponse {
+  @Expose()
+  location: string;
+}

--- a/backend/image/src/upload/upload.controller.ts
+++ b/backend/image/src/upload/upload.controller.ts
@@ -1,4 +1,5 @@
 import {
+  ClassSerializerInterceptor,
   Controller,
   HttpStatus,
   ParseFilePipe,
@@ -11,11 +12,13 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../shared/guards/jwt.guard';
 import { RequestWithUser } from '../shared/interfaces/request-with-user.interface';
+import { ImageUploadResponse } from './responses/upload-image.response';
 import { UploadService } from './upload.service';
 import { FileSizeValidator } from './validators/file-size.validator';
 import { FileTypeValidator } from './validators/file-type.validator';
 
 @Controller('upload')
+@UseInterceptors(ClassSerializerInterceptor)
 export class UploadController {
   constructor(private readonly uploadService: UploadService) {}
 
@@ -36,7 +39,7 @@ export class UploadController {
       }),
     )
     image: Express.Multer.File,
-  ): Promise<string> {
+  ): Promise<ImageUploadResponse> {
     return await this.uploadService.handleImageUpload(user, image);
   }
 }

--- a/backend/image/src/upload/upload.service.ts
+++ b/backend/image/src/upload/upload.service.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import * as fsProm from 'fs/promises';
 import * as path from 'path';
 import * as sharp from 'sharp';
-import { RequestWithUser } from 'src/shared/interfaces/request-with-user.interface';
+import { RequestWithUser } from '../shared/interfaces/request-with-user.interface';
 import {
   pathBuilder,
   validateOrCreateDirectory,
@@ -62,7 +62,8 @@ export class UploadService {
           location: `${hash}.${image.mimetype.split('/')[1]}`,
         });
       }
-      await fsProm.rename(cachedFilePath, fileTargetPath);
+      // Copy rather than move to allow for "moving" accross devices (i.e. docker volumes)
+      await fsProm.copyFile(cachedFilePath, fileTargetPath);
     } catch (error) {
       this.logger.error(error);
       if (error instanceof HttpException) {
@@ -74,7 +75,7 @@ export class UploadService {
       await fsProm.rm(cachedFilePath, { force: true });
     }
     // TODO: Notify Auth backend about user event
-    return hash;
+    return { location: `${hash}.${image.mimetype.split('/')[1]}` };
   }
 
   /**

--- a/backend/image/test/serve.e2e-spec.ts
+++ b/backend/image/test/serve.e2e-spec.ts
@@ -1,12 +1,11 @@
-import { HttpStatus, INestApplication } from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common';
 import { AppModule } from '../src/app.module';
 import { pathBuilder } from '../src/shared/helpers/file-path.helpers';
 import { copyTestFile, emptyDir } from './helpers/file.helper';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as request from 'supertest';
 import { NestFactory } from '@nestjs/core';
 import * as dotenv from 'dotenv';
+jest.mock('../src/shared/strategies/jwt.strategy');
 
 describe('Image serve e2e', () => {
   dotenv.config();

--- a/backend/image/test/upload.e2e-spec.ts
+++ b/backend/image/test/upload.e2e-spec.ts
@@ -10,6 +10,7 @@ import { JwtAuthGuard } from '../src/shared/guards/jwt.guard';
 import { FakeAuthGuardFactory } from './mocks/jwt-guard.mock';
 import * as path from 'path';
 import { pathBuilder } from '../src/shared/helpers/file-path.helpers';
+import { JwtStrategy } from '../src/shared/strategies/jwt.strategy';
 
 describe('UploadController (e2e)', () => {
   let app: INestApplication;
@@ -24,6 +25,8 @@ describe('UploadController (e2e)', () => {
       .useValue(ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }))
       .overrideGuard(JwtAuthGuard)
       .useValue(fakeGuard.getGuard())
+      .overrideProvider(JwtStrategy)
+      .useValue(null)
       .compile();
     app = moduleFixture.createNestApplication();
     uploadService = app.get<UploadService>(UploadService);

--- a/backend/image/test/upload.e2e-spec.ts
+++ b/backend/image/test/upload.e2e-spec.ts
@@ -83,6 +83,20 @@ describe('UploadController (e2e)', () => {
           1,
         );
       });
+      it('Should clean cache', async () => {
+        // ACT
+        const res = await request(app.getHttpServer())
+          .post('/upload/image')
+          .attach(
+            'image',
+            path.join(process.cwd(), 'test', 'helpers', 'test-oversized.png'),
+          );
+        // ASSERT
+        expect(res.statusCode).toEqual(HttpStatus.CREATED);
+        expect(fs.readdirSync(pathBuilder(undefined, 'cache')).length).toEqual(
+          0,
+        );
+      });
       // File size limitation not tested for obvious reasons
     });
     describe('Negative Tests', () => {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-# TODO: Update this once the backend split have been merged => Main images for every service exist
 version: "3.9"
 services:
   frontend:
@@ -69,8 +68,8 @@ services:
       - IMAGE_STORE_BASE_PATH=${IMG_IMAGE_STORE_BASE_PATH:-./disk}
       - IMAGE_STORE_INCOMING_CACHE_PATH=${IMG_IMAGE_STORE_INCOMING_CACHE_PATH:-./cache}
     # Currently disabled as this causes an error => fs.rename does not moving files between devices
-    #volumes:
-    #  - image_backend_volume:${IMG_IMAGE_STORE_BASE_PATH}
+    volumes:
+      - image_backend_volume:${IMG_IMAGE_STORE_BASE_PATH}
     links:
       - auth-backend:auth
 


### PR DESCRIPTION
# Changes
- Switch from moving to copying file from image cache to image save location
- Update tests
- add docker volume to docker compose for image backend

# For reviewers
Run `docker build -t ghcr.io/world-wide-weights/image-backend:main . ` within the image backend folder to replace the local main tag of the image with the local version. Restart the docker compose stack with:
`docker compose up -d --force-recreate`

this may require you to do `docker compose pull` to reset your local main tag to remote



Closes #238