### PR TITLE
Devops/alter pipeline trigger

### DIFF
--- a/.github/workflows/auth-backend-ci.yml
+++ b/.github/workflows/auth-backend-ci.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "backend/auth/**"
       - ".github/workflows/auth-backend-ci.yml"
+    branches:
+      - "stable"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/command-backend-ci.yml
+++ b/.github/workflows/command-backend-ci.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "backend/command/**"
       - ".github/workflows/command-backend-ci.yml"
+    branches:
+      - "stable"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"
+    branches:
+      - "stable"
   pull_request:
     branches: [main]
     paths:
       - "frontend/**"
-      - ".github/workflows/**.yml"
+      - ".github/workflows/frontend-ci.yml"
 
 env:
   NEXT_PUBLIC_CLIENT_BASE_URL: http://localhost:3002

--- a/.github/workflows/image-backend-ci.yml
+++ b/.github/workflows/image-backend-ci.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "backend/image/**"
       - ".github/workflows/image-backend-ci.yml"
+    branches:
+      - "stable"
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/query-backend-ci.yml
+++ b/.github/workflows/query-backend-ci.yml
@@ -4,12 +4,14 @@ on:
   push:
     paths:
       - "backend/query/**"
-      - ".github/workflows/**.yml"
+      - ".github/workflows/query-backend-ci.yml"
+    branches:
+      - "stable"
   pull_request:
     branches: [main]
     paths:
       - "backend/query/**"
-      - ".github/workflows/**.yml"
+      - ".github/workflows/query-backend-ci.yml"
 
 jobs:
   setup:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+# Codecov settings
+codecov:
+  bot: "Kobi"
+comment:
+  behavior: once
+github_checks:
+  annotations: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,8 @@ comment:
   behavior: once
 github_checks:
   annotations: false
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
# Changes
- Pipelines now only trigger on push on stable

This should address duplicate issues on pull requests. As our dev workflow mostly works with draft PRs testing the pipeline is still doable and easy but there will be less duplicate runs