### PR TITLE
Bug/307 progress bars is broken at large numbers

### DIFF
--- a/frontend/src/components/Item/itemPreviewList.cy.tsx
+++ b/frontend/src/components/Item/itemPreviewList.cy.tsx
@@ -27,6 +27,14 @@ describe("ItemPreviewList", () => {
         it("should not display weight difference", () => {
             cy.dataCy("div-difference").should("not.exist")
         })
+
+        it("should display progressbar", () => {
+            cy.dataCy("progressbar-progress").should("be.visible")
+        })
+
+        it("should display right percentage of progressbar", () => {
+            cy.dataCy("progressbar-progress").should("have.attr", "style", "width: 100%;")
+        })
     })
 
     describe("should display item preview list correct with weight difference", () => {
@@ -59,6 +67,12 @@ describe("ItemPreviewList", () => {
             cy.dataCy("div-difference").should("have.class", "text-gray-500")
             cy.dataCy("arrow-icon").should("have.text", "remove")
         })
+
+        it("should display right percentage of progressbar", () => {
+            cy.mount(<ItemPreviewList name="Smartphone" slug="smartphone" weight={{ value: 100, isCa: false }} heaviestWeight={{ value: 200, isCa: false }} imageUrl="https://via.placeholder.com/96.png" difference={50} />)
+
+            cy.dataCy("progressbar-progress").should("have.attr", "style", "width: 50%;")
+        })
     })
 
     describe("should display selected item correct", () => {
@@ -81,6 +95,14 @@ describe("ItemPreviewList", () => {
 
             cy.dataCy("item-preview-list").invoke("attr", "href").should("eq", "#")
             cy.dataCy("item-preview-list").should("have.class", "cursor-default")
+        })
+    })
+
+    describe("Bug Fix #307 - Wrong percentage when additional weight is smaller than value", () => {
+        it("should get display progressbar from value when it's bigger than additionalValue", () => {
+            cy.mount(<ItemPreviewList name="Smartphone" slug="smartphone" weight={{ value: 500, isCa: false }} heaviestWeight={{ value: 1000, isCa: false, additionalValue: 0 }} datacy="item-preview-list" disableLink />)
+
+            cy.dataCy("progressbar-progress").should("have.attr", "style", "width: 50%;")
         })
     })
 })

--- a/frontend/src/services/utils/weight.ts
+++ b/frontend/src/services/utils/weight.ts
@@ -16,7 +16,8 @@ export const generateWeightString = (weight: Weight): string => {
  * @returns an object with the percentage calculated and an additional percentage to show range if exist
  */
 export const generateWeightProgressBarPercentage = (weight: Weight, heaviestWeight: Weight): { percentage: number, percentageAdditional?: number } => {
-    const heaviestValue = heaviestWeight.additionalValue ?? heaviestWeight.value
+    // Get the heaviest value from heaviestWeight, ensure that additionalValue is bigger than value
+    const heaviestValue = heaviestWeight.additionalValue !== undefined ? Math.max(heaviestWeight.value, heaviestWeight.additionalValue) : heaviestWeight.value
     const { value, additionalValue } = weight
     const percentage = parseFloat((value / heaviestValue * 100).toFixed(2))
     const percentageAdditional = additionalValue ? parseFloat((additionalValue / heaviestValue * 100).toFixed(2)) : undefined

--- a/frontend/src/services/utils/weight.unit.ts
+++ b/frontend/src/services/utils/weight.unit.ts
@@ -64,6 +64,12 @@ describe("Generate Weight Process Bar Percentage", () => {
             expect(generateWeightProgressBarPercentage({ value: 50, additionalValue: 100, isCa: false }, { value: 80, additionalValue: 100, isCa: false })).to.deep.equal({ percentage: 50, percentageAdditional: 100 })
         })
     })
+
+    describe("Bug Fix #307 - Wrong percentage when additional weight is smaller than value", () => {
+        it("should get percentage from value when it's bigger than additionalValue", () => {
+            expect(generateWeightProgressBarPercentage({ value: 500, isCa: true }, { value: 1000, isCa: true, additionalValue: 0 })).to.deep.equal({ percentage: 50 })
+        })
+    })
 })
 
 describe("Calculate Median Weight", () => {


### PR DESCRIPTION
Closes #307 
- Fixes bug with wrong percentage at progress bars 
- Bug is caused by wrong data in the backend (should not be allowed in future, however we can handle it :) )
- When additionalValue is smaller than value (which should never be) the progress bar was 100% width. Now fixed.
- Includes test to prevent issue from future. 